### PR TITLE
Allows events to be retrieved with custom logic.

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,6 +37,17 @@ StripeEvent.setup do
 end
 ```
 
+## Configuration
+
+If you have built an application that has multiple Stripe accounts--say, each of your customers has their own--you may want to define your own way of retrieving events from Stripe (e.g. perhaps you want to use the `user_id` paramter from the top level to detect the customer for the event, then grab their specific API key). You can do this:
+
+```ruby
+StripeEvent.event_retriever = Proc.new do |params| 
+  secret_key = Account.find_by_stripe_user_id(params[:user_id]).secret_key
+  Stripe::Event.retrieve(params, secret_key)
+end
+```
+
 ## Register webhook url with Stripe
 
 ![Setup webhook url](https://raw.github.com/integrallis/stripe_event/master/screenshots/dashboard-webhook.png "webhook setup")

--- a/app/controllers/stripe_event/webhook_controller.rb
+++ b/app/controllers/stripe_event/webhook_controller.rb
@@ -1,7 +1,7 @@
 module StripeEvent
   class WebhookController < ActionController::Base
     def event
-      event = Stripe::Event.retrieve(params[:id])
+      event = StripeEvent.event_retriever.call(params)
       StripeEvent.publish(event)
       head :ok
     rescue Stripe::StripeError

--- a/lib/stripe_event.rb
+++ b/lib/stripe_event.rb
@@ -4,6 +4,9 @@ require "stripe_event/subscriber"
 require "stripe_event/types"
 
 module StripeEvent
+  mattr_accessor :event_retriever
+  self.event_retriever = Proc.new {|params| Stripe::Event.retrieve(params[:id]) }
+
   class << self
     alias_method :setup, :instance_eval
   end

--- a/spec/lib/stripe_event_spec.rb
+++ b/spec/lib/stripe_event_spec.rb
@@ -62,4 +62,17 @@ describe StripeEvent do
       }.to yield_with_args(event)
     end
   end
+
+  context "retrieving" do
+    it "uses Stripe::Event as the default event retriever" do
+      Stripe::Event.should_receive(:retrieve).with('1')
+      StripeEvent.event_retriever.call({:id => '1'})
+    end
+
+    it "allows setting an event_retriever" do
+      event = stub(:event)
+      StripeEvent.event_retriever = Proc.new {|params| event }
+      StripeEvent.event_retriever.call({:id => '1'}).should == event
+    end
+  end
 end


### PR DESCRIPTION
Useful for if your application has more than one Stripe account (say:
one per customer) and you want to find the correct API key to use when
doing the Stripe::Event.retrieve call.
