### PR TITLE
Use Stripe::Event.construct_from for event_retriever

### DIFF
--- a/lib/stripe_event.rb
+++ b/lib/stripe_event.rb
@@ -16,7 +16,9 @@ module StripeEvent
     end
 
     def publish(event)
-      backend.publish(event[:type], event)
+      type = event[:type]
+      type ||= event.type if event.respond_to?(:type)
+      backend.publish(type, event)
     end
 
     def subscribe(*names, &block)

--- a/spec/lib/stripe_event_spec.rb
+++ b/spec/lib/stripe_event_spec.rb
@@ -42,4 +42,17 @@ describe StripeEvent do
     event = described_class.event_retriever.call(params)
     expect(event).to eq params
   end
+
+  it "allows using an event_retriever that utilizes Stripe::Event.construct_from" do
+    params = { 'id' => '1', 'type' => 'charge.succeeded' }
+
+    described_class.event_retriever = Proc.new { |params| Stripe::Event.construct_from(params) }
+    described_class.setup do
+      subscribe 'charge.succeeded' do |event|
+        raise "this code should be run"
+      end
+    end
+    event = described_class.event_retriever.call(params)
+    expect {described_class.publish(event)}.to raise_error(StandardError)
+  end
 end


### PR DESCRIPTION
This commit along with the proper event_retriever allows stripe_event
to accept test webhooks directly from stripe.

I learned some interesting things with this commit. First, `Stripe::Event.construct_from` can be used to convert json into a Stripe::Event. That is really useful because it ensures all the behaviors are the same rather than using json directly as the event in the subscribe block.

But this wasn't working at first. Turns out that `construct_from` is sensitive to symbol keys in the hash. If string keys are used, `event[:type]` returns nil. Here's an example:

``` ruby
1.9.3p429 :046 > e = Stripe::Event.construct_from(JSON.parse("{\"id\":1}"))
 => #<Stripe::Event:0x2df1be4 id=1> JSON: {"id":1} 
1.9.3p429 :047 > e[:id]
 => nil 
1.9.3p429 :048 > e['id']
 => nil 
1.9.3p429 :049 > e.id
 => 1 
1.9.3p429 :050 > e = Stripe::Event.construct_from(JSON.parse("{\"id\":1}").symbolize_keys)
 => #<Stripe::Event:0x38651d4> JSON: {"id":1} 
1.9.3p429 :051 > e[:id]
 => 1 
1.9.3p429 :052 > e['id']
 => 1 
1.9.3p429 :053 > e.id
 => 1 
```

I didn't really dig into why this happens, but the supporting test calls the `.type` method in `publish` if `event[:type]` is nil. Here's the event_retriever as it could be implemented:

``` ruby
if Rails.env.development? || Rails.env.test?
  StripeEvent.event_retriever = lambda {|params| Stripe::Event.construct_from(params) }
end
```

This works nicely for me during testing. I hope you'll consider merging it.
