### PR TITLE
Pass user-generated Stripe exceptions through

### DIFF
--- a/app/controllers/stripe_event/webhook_controller.rb
+++ b/app/controllers/stripe_event/webhook_controller.rb
@@ -3,7 +3,7 @@ module StripeEvent
     def event
       StripeEvent.instrument(params)
       head :ok
-    rescue Stripe::StripeError
+    rescue StripeEvent::UnauthorizedError
       head :unauthorized
     end
   end

--- a/lib/stripe_event.rb
+++ b/lib/stripe_event.rb
@@ -11,7 +11,11 @@ module StripeEvent
     end
 
     def instrument(params)
-      event = event_retriever.call(params)
+      begin
+        event = event_retriever.call(params)
+      rescue Stripe::StripeError
+        raise UnauthorizedError
+      end
       publish(event)
     end
 
@@ -28,6 +32,8 @@ module StripeEvent
       end
     end
   end
+
+  class UnauthorizedError < StandardError; end
 
   self.backend = ActiveSupport::Notifications
   self.event_retriever = lambda { |params| Stripe::Event.retrieve(params[:id]) }

--- a/spec/controllers/webhook_controller_spec.rb
+++ b/spec/controllers/webhook_controller_spec.rb
@@ -19,6 +19,15 @@ describe StripeEvent::WebhookController do
     expect(response.code).to eq '401'
   end
 
+  it "ensures user-generated Stripe exceptions pass through" do
+    StripeEvent.setup do
+      subscribe('charge.succeeded') { |e| raise Stripe::StripeError }
+    end
+    stub_event('evt_charge_succeeded')
+
+    expect {event_post :id => 'evt_charge_succeeded'}.to raise_error(Stripe::StripeError)
+  end
+
   it "succeeds with a custom event retriever" do
     StripeEvent.event_retriever = Proc.new { |params| params }
 


### PR DESCRIPTION
This ensures that when StripeError is generated during the subscribed
block, the exception is passed through to layers past StripeEvent
rather than caught and returning a 401. Mostly useful during development
to let developers see their exceptions.

Re issue #23
