### PR TITLE
Subscribe to `account.application.deauthorized` events

### DIFF
--- a/lib/stripe_event.rb
+++ b/lib/stripe_event.rb
@@ -17,7 +17,7 @@ module StripeEvent
         event = event_retriever.call(params)
       rescue Stripe::AuthenticationError => e
         if params[:type] == "account.application.deauthorized"
-          event = Stripe::Event.construct_from(params)
+          event = Stripe::Event.construct_from(params.deep_symbolize_keys)
         else
           raise UnauthorizedError.new(e)
         end


### PR DESCRIPTION
When a Stripe Connect application receives an `account.application.deauthorized` event, the tokens have already been decommissioned, so the event_retriever is pretty much guaranteed to throw a `Stripe::AuthenticationError`, and no subsequent event subscriptions fire.

Instead, if we receive a `Stripe::AuthenticationError` from a known account and the type is `account.application.deauthorized`, we can be confident that this was an authorized webhook from Stripe. Under this scenario, construct a `Stripe::Event` from the passed params instead of retrieving the Event from Stripe's API and fire the subscribed hooks directly.

Fixes #15
