### PR TITLE
Allow for controlled event rejection

### DIFF
--- a/lib/stripe_event.rb
+++ b/lib/stripe_event.rb
@@ -25,7 +25,7 @@ module StripeEvent
         raise UnauthorizedError.new(e)
       end
 
-      backend.instrument namespace.call(event[:type]), event
+      backend.instrument(namespace.call(event[:type]), event) if event
     end
 
     def subscribe(name, callable = Proc.new)

--- a/spec/lib/stripe_event_spec.rb
+++ b/spec/lib/stripe_event_spec.rb
@@ -26,6 +26,17 @@ describe StripeEvent do
     end
   end
 
+  describe "event_retriever rejecting events" do
+    before do
+      expect(ActiveSupport::Notifications).to receive(:instrument).never
+      StripeEvent.event_retriever = lambda { |params| nil }
+    end
+
+    it "should not retrieve anything" do
+      StripeEvent.instrument(id: 'evt_reject', type: 'charge.succeeded')
+    end
+  end
+
   describe "subscribing to a specific event type" do
     before do
       expect(charge_succeeded).to receive(:[]).with(:type).and_return('charge.succeeded')


### PR DESCRIPTION
This adds the ability to selectively reject an event. For example,
if you want to prevent replay attacks you would set up your event
retriever to record every event id that comes in and reject
duplicates. Or, if you are still receiving events for connected
Stripe accounts that are deactivated in your system, you could
drop their events on the floor.
