### PR TITLE
Add StripeEvent.listening?

### DIFF
--- a/lib/stripe_event.rb
+++ b/lib/stripe_event.rb
@@ -35,6 +35,11 @@ module StripeEvent
     def all(callable = Proc.new)
       subscribe nil, callable
     end
+
+    def listening?(name)
+      namespaced_name = namespace.call(name)
+      backend.notifier.listening?(namespaced_name)
+    end
   end
 
   class Namespace < Struct.new(:value, :delimiter)

--- a/spec/lib/stripe_event_spec.rb
+++ b/spec/lib/stripe_event_spec.rb
@@ -152,6 +152,28 @@ describe StripeEvent do
     end
   end
 
+  describe ".listening?" do
+    it "returns true when there is a subscriber for a matching event type" do
+      StripeEvent.subscribe('customer.', &subscriber)
+
+      expect(StripeEvent.listening?('customer.card')).to be true
+      expect(StripeEvent.listening?('customer.')).to be true
+    end
+
+    it "returns false when there is not a subscriber for a matching event type" do
+      StripeEvent.subscribe('customer.', &subscriber)
+
+      expect(StripeEvent.listening?('account')).to be false
+    end
+
+    it "returns true when a subscriber is subscribed to all events" do
+      StripeEvent.all(&subscriber)
+
+      expect(StripeEvent.listening?('customer.')).to be true
+      expect(StripeEvent.listening?('account')).to be true
+    end
+  end
+
   describe StripeEvent::NotificationAdapter do
     let(:adapter) { StripeEvent.adapter }
 


### PR DESCRIPTION
Often, I find it helpful in my retrievers to know whether `StripeEvent` has any registered listeners for a particular event type. This allows me to avoid a `Stripe::Event.retrieve` API call to Stripe if I am not even interested in processing the event. Currently, I do this in my retrievers:

``` ruby
class StripeEventRetriever
  def call(params)
    return nil unless processing_events_of_type?(params[:type])
    # <snip>
  end

private
  def processing_events_of_type?(event_type)
    namespaced_type = StripeEvent.namespace.call(event_type)
    StripeEvent.backend.notifier.listening?(namespaced_type)
  end
end
```

Since `StripeEvent.namespace` and `StripeEvent.backend` are internal implementation details, I think it would be nice to provide a `StripeEvent.listening?` API which provides this functionality without exposing users of the gem to notification internals.
