### PR TITLE
Allow post method in example spec

### DIFF
--- a/README.md
+++ b/README.md
@@ -142,10 +142,10 @@ end
 Handling webhooks is a critical piece of modern billing systems. Verifying the behavior of StripeEvent subscribers can be done fairly easily by stubbing out the HTTP request used to authenticate the webhook request. Tools like [Webmock](https://github.com/bblimke/webmock) and [VCR](https://github.com/vcr/vcr) work well. [RequestBin](http://requestb.in/) is great for collecting the payloads. For exploratory phases of development, [UltraHook](http://www.ultrahook.com/) and other tools can forward webhook requests directly to localhost. You can check out [test-hooks](https://github.com/invisiblefunnel/test-hooks), an example Rails application to see how to test StripeEvent subscribers with RSpec request specs and Webmock. A quick look:
 
 ```ruby
-# spec/requests/billing_events_spec.rb
+# spec/controllers/webhook_controller_spec.rb
 require 'spec_helper'
 
-describe "Billing Events" do
+describe StripeEvent::WebhookController, type: :controller do
   def stub_event(fixture_id, status = 200)
     stub_request(:get, "https://api.stripe.com/v1/events/#{fixture_id}").
       to_return(status: status, body: File.read("spec/support/fixtures/#{fixture_id}.json"))


### PR DESCRIPTION
I noticed that the example spec does not work because `post` is
undefined (it's intended for controller specs). I found that
setting up my specs to work off of the WebHooksController allowed
me to use the `post` helper so my specs work now.
