### PR TITLE
Don't retrieve event if we're not listening to it

### DIFF
--- a/lib/stripe_event.rb
+++ b/lib/stripe_event.rb
@@ -13,6 +13,8 @@ module StripeEvent
     alias :setup :configure
 
     def instrument(params)
+      return unless listening?(parmas[:type])
+      
       begin
         event = event_retriever.call(params)
       rescue Stripe::AuthenticationError => e


### PR DESCRIPTION
Take this as feature suggestion. Is there any reason we're retrieving events we're not listening for?
