### PR TITLE
Update README with Rails 4 mounting syntax

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ gem 'stripe_event'
 
 ```ruby
 # config/routes.rb
-mount StripeEvent::Engine => '/my-chosen-path' # provide a custom path
+mount StripeEvent::Engine, at: '/my-chosen-path' # provide a custom path
 ```
 
 ## Usage


### PR DESCRIPTION
Thanks for maintaining this gem.

In Rails 4, the syntax for mounting an engine changed to:

```
mount Blorgh::Engine, at: "blorgh"
```

http://guides.rubyonrails.org/engines.html#generating-an-engine

This PR updates the stripe_event README to use that newer syntax. 
