### PR TITLE
Add an event finalizer

### DIFF
--- a/spec/controllers/webhook_controller_spec.rb
+++ b/spec/controllers/webhook_controller_spec.rb
@@ -34,6 +34,17 @@ describe StripeEvent::WebhookController do
     expect(count).to eq 0
   end
 
+  it "calls the event finalizer if there is one" do
+    count = 0
+    StripeEvent.event_finalizer = lambda { |event| count += 1 }
+    stub_event('evt_charge_succeeded')
+
+    webhook id: 'evt_charge_succeeded'
+
+    expect(response.code).to eq '200'
+    expect(count).to eq 1
+  end
+
   it "denies access with invalid event data" do
     count = 0
     StripeEvent.subscribe('charge.succeeded') { |evt| count += 1 }

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -16,6 +16,7 @@ RSpec.configure do |config|
     @event_retriever = StripeEvent.event_retriever
     @notifier = StripeEvent.backend.notifier
     StripeEvent.backend.notifier = @notifier.class.new
+    StripeEvent.event_finalizer = nil
   end
 
   config.after do


### PR DESCRIPTION
This adds an `event_finalizer` hook that will be called after all
subscribers have been notified of an event. This lets us record
a completely successful event, while allowing Stripe to retry
any failures.

Fixes #53