### PR TITLE
Basic authentication support

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,12 +80,12 @@ To prevent this, StripeEvent supports using HTTP Basic authentication on your we
 
 2. Configure StripeEvent to require that secret be used as a basic authentication password, using code along the lines of these examples:
 
-```ruby
-# STRIPE_WEBHOOK_SECRET environment variable
-StripeEvent.authentication_secret = ENV['STRIPE_WEBHOOK_SECRET']
-# stripe_webhook_secret key in secrets.yml file
-StripeEvent.authentication_secret = Rails.application.secrets.stripe_webhook_secret
-```
+    ```ruby
+    # STRIPE_WEBHOOK_SECRET environment variable
+    StripeEvent.authentication_secret = ENV['STRIPE_WEBHOOK_SECRET']
+    # stripe_webhook_secret key in secrets.yml file
+    StripeEvent.authentication_secret = Rails.application.secrets.stripe_webhook_secret
+    ```
 
 3. When you specify your webhook's URL in Stripe's settings, include the secret as a password in the URL, along with any username:
 

--- a/README.md
+++ b/README.md
@@ -70,6 +70,29 @@ StripeEvent.subscribe 'customer.card.' do |event|
 end
 ```
 
+## Securing your webhook endpoint
+
+StripeEvent automatically fetches events from Stripe to ensure they haven't been forged. However, that doesn't prevent an attacker who knows your endpoint name and an event's ID from forcing your server to process a legitimate event twice. If that event triggers some useful action, like generating a license key or enabling a delinquent account, you could end up giving something the attacker is supposed to pay for away for free.
+
+To prevent this, StripeEvent supports using HTTP Basic authentication on your webhook endpoint. If only Stripe knows the basic authentication password, this ensures that the request really comes from Stripe. Here's what you do:
+
+1. Arrange for a secret key to be available in your application's environment variables or `secrets.yml` file. You can generate a suitable secret with the `rake secret` command. (Remember, the `secrets.yml` file shouldn't contain production secrets directly; it should use ERB to include them.)
+
+2. Configure StripeEvent to require that secret be used as a basic authentication password, using code along the lines of these examples:
+
+```ruby
+# STRIPE_WEBHOOK_SECRET environment variable
+StripeEvent.authentication_secret = ENV['STRIPE_WEBHOOK_SECRET']
+# stripe_webhook_secret key in secrets.yml file
+StripeEvent.authentication_secret = Rails.application.secrets.stripe_webhook_secret
+```
+
+3. When you specify your webhook's URL in Stripe's settings, include the secret as a password in the URL, along with any username:
+
+    https://stripe:my-secret-key@myapplication.com/my-webhook-path
+
+This is only truly secure if your webhook endpoint is accessed over SSL, which Stripe strongly recommends anyway.
+
 ## Configuration
 
 If you have built an application that has multiple Stripe accounts--say, each of your customers has their own--you may want to define your own way of retrieving events from Stripe (e.g. perhaps you want to use the [user_id parameter](https://stripe.com/docs/apps/getting-started#webhooks) from the top level to detect the customer for the event, then grab their specific API key). You can do this:

--- a/README.md
+++ b/README.md
@@ -89,7 +89,7 @@ StripeEvent.authentication_secret = Rails.application.secrets.stripe_webhook_sec
 
 3. When you specify your webhook's URL in Stripe's settings, include the secret as a password in the URL, along with any username:
 
-    https://stripe:my-secret-key@myapplication.com/my-webhook-path
+        https://stripe:my-secret-key@myapplication.com/my-webhook-path
 
 This is only truly secure if your webhook endpoint is accessed over SSL, which Stripe strongly recommends anyway.
 

--- a/app/controllers/stripe_event/webhook_controller.rb
+++ b/app/controllers/stripe_event/webhook_controller.rb
@@ -1,5 +1,12 @@
 module StripeEvent
   class WebhookController < ActionController::Base
+    before_action do
+      StripeEvent.authentication_secret.nil? or \
+        authenticate_or_request_with_http_basic do |username, password|
+          password == StripeEvent.authentication_secret
+        end
+    end
+    
     def event
       StripeEvent.instrument(params)
       head :ok

--- a/app/controllers/stripe_event/webhook_controller.rb
+++ b/app/controllers/stripe_event/webhook_controller.rb
@@ -1,6 +1,6 @@
 module StripeEvent
   class WebhookController < ActionController::Base
-    before_action do
+    before_filter do
       StripeEvent.authentication_secret.nil? or \
         authenticate_or_request_with_http_basic do |username, password|
           password == StripeEvent.authentication_secret

--- a/app/controllers/stripe_event/webhook_controller.rb
+++ b/app/controllers/stripe_event/webhook_controller.rb
@@ -1,10 +1,11 @@
 module StripeEvent
   class WebhookController < ActionController::Base
     before_filter do
-      StripeEvent.authentication_secret.nil? or \
+      if StripeEvent.authentication_secret
         authenticate_or_request_with_http_basic do |username, password|
           password == StripeEvent.authentication_secret
         end
+      end
     end
     
     def event

--- a/lib/stripe_event.rb
+++ b/lib/stripe_event.rb
@@ -4,7 +4,7 @@ require "stripe_event/engine" if defined?(Rails)
 
 module StripeEvent
   class << self
-    attr_accessor :adapter, :backend, :event_retriever, :namespace
+    attr_accessor :adapter, :backend, :event_retriever, :namespace, :authentication_secret
 
     def configure(&block)
       raise ArgumentError, "must provide a block" unless block_given?

--- a/spec/controllers/webhook_controller_spec.rb
+++ b/spec/controllers/webhook_controller_spec.rb
@@ -53,11 +53,9 @@ describe StripeEvent::WebhookController do
   end
   
   context "with an authentication secret" do
-    def webhook(secret, params)
-      if secret
-        request.env['HTTP_AUTHORIZATION'] = ActionController::HttpAuthentication::Basic.encode_credentials('user', secret)
-      end
-      super params
+    def webhook_with_secret(secret, params)
+      request.env['HTTP_AUTHORIZATION'] = ActionController::HttpAuthentication::Basic.encode_credentials('user', secret)
+      webhook params
     end
     
     before(:each) { StripeEvent.authentication_secret = "secret" }
@@ -66,21 +64,21 @@ describe StripeEvent::WebhookController do
     it "rejects requests with no secret" do
       stub_event('evt_charge_succeeded')
     
-      webhook nil, id: 'evt_charge_succeeded'
+      webhook id: 'evt_charge_succeeded'
       expect(response.code).to eq '401'
     end
   
     it "rejects requests with incorrect secret" do
       stub_event('evt_charge_succeeded')
     
-      webhook 'incorrect', id: 'evt_charge_succeeded'
+      webhook_with_secret 'incorrect', id: 'evt_charge_succeeded'
       expect(response.code).to eq '401'
     end
   
     it "accepts requests with correct secret" do
       stub_event('evt_charge_succeeded')
     
-      webhook 'secret', id: 'evt_charge_succeeded'
+      webhook_with_secret 'secret', id: 'evt_charge_succeeded'
       expect(response.code).to eq '200'
     end
   end


### PR DESCRIPTION
Pursuant to #53, this branch adds basic authentication support to StripeEvent.

Basic authentication is supported in the simplest way possible:

1. The module's user sets a `StripeEvent.authentication_secret` attribute to their desired password.
2. If `authentication_secret` is set, a new `before_action` in `WebhookController` ensures that the request is appropriately authenticated, and returns a 401 otherwise.
3. If `authentication_secret` is not set, the module behaves as it does currently. All previously-existing tests pass unmodified.

This branch does not add a default way to determine the secret, a deprecation warning if the user doesn't specify a secret, or anything else of that sort. I'm by no means opposed to such things, but since this is my first pull request, I don't feel qualified to make those sorts of design decisions. It does, however, include new tests to ensure this feature is working as intended and a section in the README explaining how to enable it.

Suggestions welcome.