### PR TITLE
Update step two of CONTRIBUTING.md to include appraisal before exec rake

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -9,7 +9,7 @@ Awesome. We love help, but before getting started, please read:
 1. Fork the repo.
 
 2. Run the tests. We only take pull requests with passing tests, and it's great
-to know that you have a clean slate: `bundle && bundle exec rake`
+to know that you have a clean slate: `bundle && appraisal && bundle exec rake`
 
 3. Add a test for your change. Only refactoring and documentation changes
 require no new tests. If you are adding functionality or fixing a bug, we need


### PR DESCRIPTION
I had to invoke `appraisal install` before the command in CONTRIBUTING.md would work as expected. Updating that here so others don't run into the same problem.