### PR TITLE
add ability to trust incoming event without additional request to stripe

### DIFF
--- a/spec/controllers/webhook_controller_spec.rb
+++ b/spec/controllers/webhook_controller_spec.rb
@@ -2,13 +2,21 @@ require 'rails_helper'
 require 'spec_helper'
 
 describe StripeEvent::WebhookController do
+  include_context 'restore_state'
+
+  routes { StripeEvent::Engine.routes }
+
+  def payload(identifier)
+    File.read("spec/support/fixtures/#{identifier}.json")
+  end
+
   def stub_event(identifier, status = 200)
     stub_request(:get, "https://api.stripe.com/v1/events/#{identifier}").
-      to_return(status: status, body: File.read("spec/support/fixtures/#{identifier}.json"))
+      to_return(status: status, body: payload(identifier))
   end
 
   def webhook(params)
-    post :event, params.merge(use_route: :stripe_event)
+    post :event, params
   end
 
   it "succeeds with valid event data" do
@@ -35,6 +43,7 @@ describe StripeEvent::WebhookController do
   end
 
   it "denies access with invalid event data" do
+
     count = 0
     StripeEvent.subscribe('charge.succeeded') { |evt| count += 1 }
     stub_event('evt_invalid_id', 404)
@@ -51,35 +60,58 @@ describe StripeEvent::WebhookController do
 
     expect { webhook id: 'evt_charge_succeeded' }.to raise_error(Stripe::StripeError, /testing/)
   end
-  
+
   context "with an authentication secret" do
     def webhook_with_secret(secret, params)
       request.env['HTTP_AUTHORIZATION'] = ActionController::HttpAuthentication::Basic.encode_credentials('user', secret)
       webhook params
     end
-    
+
     before(:each) { StripeEvent.authentication_secret = "secret" }
     after(:each) { StripeEvent.authentication_secret = nil }
-  
+
     it "rejects requests with no secret" do
       stub_event('evt_charge_succeeded')
-    
+
       webhook id: 'evt_charge_succeeded'
       expect(response.code).to eq '401'
     end
-  
+
     it "rejects requests with incorrect secret" do
       stub_event('evt_charge_succeeded')
-    
+
       webhook_with_secret 'incorrect', id: 'evt_charge_succeeded'
       expect(response.code).to eq '401'
     end
-  
+
     it "accepts requests with correct secret" do
       stub_event('evt_charge_succeeded')
-    
+
       webhook_with_secret 'secret', id: 'evt_charge_succeeded'
       expect(response.code).to eq '200'
+    end
+  end
+
+  context 'with trust incoming event true' do
+    let(:trust_event) { true }
+
+    it 'succeeds with valid event data' do
+      count = 0
+      StripeEvent.event_retriever = nil
+      StripeEvent.subscribe('charge.succeeded') { |evt| count += 1 }
+      post :event, JSON.parse(payload('evt_charge_succeeded'))
+
+      expect(response.code).to eq '200'
+      expect(count).to eq 1
+    end
+
+    it 'define custom event_retriever' do
+      custom_event_retriever = lambda { |evt| nil }
+      StripeEvent.event_retriever = custom_event_retriever
+      post :event, JSON.parse(payload('evt_charge_succeeded'))
+
+      expect(response.code).to eq '200'
+      expect(StripeEvent.event_retriever).to eq custom_event_retriever
     end
   end
 end

--- a/spec/lib/stripe_event_spec.rb
+++ b/spec/lib/stripe_event_spec.rb
@@ -1,6 +1,8 @@
 require 'spec_helper'
 
 describe StripeEvent do
+  include_context 'restore_state'
+
   let(:events) { [] }
   let(:subscriber) { ->(evt){ events << evt } }
   let(:charge_succeeded) { double('charge succeeded') }

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -2,24 +2,14 @@ require 'coveralls'
 Coveralls.wear!
 
 require 'webmock/rspec'
-require File.expand_path('../../lib/stripe_event', __FILE__)
-Dir[File.expand_path('../spec/support/**/*.rb', __FILE__)].each { |f| require f }
 
+require File.expand_path('../../lib/stripe_event', __FILE__)
+
+Dir[File.expand_path('../support/**/*.rb', __FILE__)].each { |f| require f }
 RSpec.configure do |config|
   config.order = 'random'
 
   config.expect_with :rspec do |c|
     c.syntax = :expect
-  end
-
-  config.before do
-    @event_retriever = StripeEvent.event_retriever
-    @notifier = StripeEvent.backend.notifier
-    StripeEvent.backend.notifier = @notifier.class.new
-  end
-
-  config.after do
-    StripeEvent.event_retriever = @event_retriever
-    StripeEvent.backend.notifier = @notifier
   end
 end

--- a/spec/support/shared_context/restore_state.rb
+++ b/spec/support/shared_context/restore_state.rb
@@ -1,0 +1,17 @@
+shared_context 'restore_state' do
+    let(:trust_event) { false }
+
+    before do
+      @trust_incoming_event = StripeEvent.trust_incoming_event
+      StripeEvent.trust_incoming_event = trust_event
+      @event_retriever = StripeEvent.event_retriever
+      @notifier = StripeEvent.backend.notifier
+      StripeEvent.backend.notifier = @notifier.class.new
+    end
+
+    after do
+      StripeEvent.event_retriever = @event_retriever
+      StripeEvent.backend.notifier = @notifier
+      StripeEvent.trust_incoming_event = @trust_incoming_event
+    end
+end


### PR DESCRIPTION
I think its good idea do not make additional request to stripe API if you want to trust incoming events. Default behavior is same as was but i've add option like trust incoming stripe events also i've add tests for this. If you have any suggestions plz let me know hope you find this changes is useful. Thanks.