### PR TITLE
Prefer before_action over before_filter

### DIFF
--- a/app/controllers/stripe_event/webhook_controller.rb
+++ b/app/controllers/stripe_event/webhook_controller.rb
@@ -1,11 +1,9 @@
 module StripeEvent
   class WebhookController < ActionController::Base
-    before_filter do
-      if StripeEvent.authentication_secret
-        authenticate_or_request_with_http_basic do |username, password|
-          password == StripeEvent.authentication_secret
-        end
-      end
+    if respond_to?(:before_action)
+      before_action :request_authentication
+    else
+      before_filter :request_authentication
     end
 
     def event
@@ -21,6 +19,14 @@ module StripeEvent
     def log_error(e)
       logger.error e.message
       e.backtrace.each { |line| logger.error "  #{line}" }
+    end
+
+    def request_authentication
+      if StripeEvent.authentication_secret
+        authenticate_or_request_with_http_basic do |username, password|
+          password == StripeEvent.authentication_secret
+        end
+      end
     end
   end
 end


### PR DESCRIPTION
Futureproofs for deprecation of before_filter in rails 5.1.

Fixes #69.