### PR TITLE
Bugfix for undefined method `deep_symbolize_keys'

### DIFF
--- a/lib/stripe_event.rb
+++ b/lib/stripe_event.rb
@@ -17,6 +17,9 @@ module StripeEvent
         event = event_retriever.call(params)
       rescue Stripe::AuthenticationError => e
         if params[:type] == "account.application.deauthorized"
+          # Convert the ActionController::Parameters object to a plain hash
+          # so deep_symbolize_keys will work.
+          params = params.permit!.to_hash
           event = Stripe::Event.construct_from(params.deep_symbolize_keys)
         else
           raise UnauthorizedError.new(e)

--- a/spec/lib/stripe_event_spec.rb
+++ b/spec/lib/stripe_event_spec.rb
@@ -62,6 +62,7 @@ describe StripeEvent do
       it "calls the subscriber with the retrieved event" do
         StripeEvent.subscribe('account.application.deauthorized', subscriber)
 
+        # TODO: Change the hash going into this method to be an ActionController::Parameters object.
         StripeEvent.instrument(id: 'evt_account_application_deauthorized', type: 'account.application.deauthorized')
 
         expect(events.first.type).to    eq 'account.application.deauthorized'
@@ -77,6 +78,7 @@ describe StripeEvent do
       it "calls the subscriber with the retrieved event" do
         StripeEvent.subscribe('account.application.deauthorized', subscriber)
 
+        # TODO: Change the hash going into this method to be an ActionController::Parameters object.
         StripeEvent.instrument({ id: 'evt_account_application_deauthorized', type: 'account.application.deauthorized' }.with_indifferent_access)
 
         expect(events.first.type).to    eq 'account.application.deauthorized'


### PR DESCRIPTION
I'm using stripe_event on a new Rails 5 project, while listening to the
webhook "account.application.deauthorized" in my tests & in my event application
logs I was noticing the error :

```
NoMethodError:
       undefined method `deep_symbolize_keys' for
       #<ActionController::Parameters:0x007fe84b498780>
```

This was being thrown on lib/stripe_event.rb around line 20.

I wrote a fix which converts the ActionController::Parameters into a
hash, however I was unable to get the stripe_events specs running my end
(When I ran `bundle exec rake spec` I kept running into "cannot load
such file" errors). I've annotated in the specs where I believe they need to be
corrected.

I'm happy to update the specs if someone can't point me in the right
direction on how to set them up.