### PR TITLE
Use variable_size_secure_compare for HTTP auth

### DIFF
--- a/app/controllers/stripe_event/webhook_controller.rb
+++ b/app/controllers/stripe_event/webhook_controller.rb
@@ -24,7 +24,7 @@ module StripeEvent
     def request_authentication
       if StripeEvent.authentication_secret
         authenticate_or_request_with_http_basic do |username, password|
-          password == StripeEvent.authentication_secret
+          ActiveSupport::SecurityUtils.variable_size_secure_compare password, StripeEvent.authentication_secret
         end
       end
     end


### PR DESCRIPTION
This fixes a very minor security issue related to timing attacks.

This changes is similar to the patch for CVE-2015-7576 for Rails 5.0.0.beta1.1 and other versions. See this advisory for more details: https://groups.google.com/forum/#!msg/rubyonrails-security/ANv0HDHEC3k/mt7wNGxbFQAJ