### PR TITLE
Support for Rails 5.1

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,5 @@ spec/dummy/.sass-cache
 Gemfile.lock
 gemfiles/*.lock
 coverage/*
+.ruby-version
+.ruby-gemset

--- a/.travis.yml
+++ b/.travis.yml
@@ -9,9 +9,13 @@ rvm:
 gemfile:
   - gemfiles/rails4.1.gemfile
   - gemfiles/rails4.2.gemfile
+  - gemfiles/rails5.0.gemfile
+  - gemfiles/rails5.1.gemfile
 
 matrix:
   include:
+    - rvm: 2.4.2
+      gemfile: gemfiles/rails5.1.gemfile
     - rvm: 2.1.9
       gemfile: gemfiles/rails3.2.gemfile
   fast_finish: true

--- a/Appraisals
+++ b/Appraisals
@@ -1,5 +1,6 @@
 appraise "rails3.2" do
   gem "rails", "~> 3.2.0"
+  gem "test-unit", "~> 3.0"
 end
 
 appraise "rails4.1" do
@@ -8,4 +9,12 @@ end
 
 appraise "rails4.2" do
   gem "rails", "~> 4.2.0"
+end
+
+appraise "rails5.0" do
+  gem "rails", "~> 5.0.0"
+end
+
+appraise "rails5.1" do
+  gem "rails", "~> 5.1.0"
 end

--- a/gemfiles/rails4.1.gemfile
+++ b/gemfiles/rails4.1.gemfile
@@ -4,4 +4,4 @@ source "https://rubygems.org"
 
 gem "rails", "~> 4.1.0"
 
-gemspec :path => "../"
+gemspec path: "../"

--- a/gemfiles/rails4.2.gemfile
+++ b/gemfiles/rails4.2.gemfile
@@ -4,4 +4,4 @@ source "https://rubygems.org"
 
 gem "rails", "~> 4.2.0"
 
-gemspec :path => "../"
+gemspec path: "../"

--- a/gemfiles/rails5.0.gemfile
+++ b/gemfiles/rails5.0.gemfile
@@ -2,7 +2,6 @@
 
 source "https://rubygems.org"
 
-gem "rails", "~> 3.2.0"
-gem "test-unit", "~> 3.0"
+gem "rails", "~> 5.0.0"
 
 gemspec path: "../"

--- a/gemfiles/rails5.1.gemfile
+++ b/gemfiles/rails5.1.gemfile
@@ -2,7 +2,6 @@
 
 source "https://rubygems.org"
 
-gem "rails", "~> 3.2.0"
-gem "test-unit", "~> 3.0"
+gem "rails", "~> 5.1.0"
 
 gemspec path: "../"

--- a/lib/stripe_event.rb
+++ b/lib/stripe_event.rb
@@ -17,6 +17,10 @@ module StripeEvent
         event = event_retriever.call(params)
       rescue Stripe::AuthenticationError => e
         if params[:type] == "account.application.deauthorized"
+          if defined?(ActionController::Parameters) && params.is_a?(ActionController::Parameters)
+            params = params.permit!.to_h
+          end
+
           event = Stripe::Event.construct_from(params.deep_symbolize_keys)
         else
           raise UnauthorizedError.new(e)

--- a/spec/controllers/webhook_controller_spec.rb
+++ b/spec/controllers/webhook_controller_spec.rb
@@ -1,14 +1,20 @@
 require 'rails_helper'
 require 'spec_helper'
 
-describe StripeEvent::WebhookController do
+describe StripeEvent::WebhookController, type: :controller do
   def stub_event(identifier, status = 200)
     stub_request(:get, "https://api.stripe.com/v1/events/#{identifier}").
       to_return(status: status, body: File.read("spec/support/fixtures/#{identifier}.json"))
   end
 
   def webhook(params)
-    post :event, params
+    data = if Rails::VERSION::MAJOR > 4
+      { params: params }
+    else
+      params
+    end
+
+    post :event, data
   end
 
   routes { StripeEvent::Engine.routes }
@@ -53,33 +59,33 @@ describe StripeEvent::WebhookController do
 
     expect { webhook id: 'evt_charge_succeeded' }.to raise_error(Stripe::StripeError, /testing/)
   end
-  
+
   context "with an authentication secret" do
     def webhook_with_secret(secret, params)
       request.env['HTTP_AUTHORIZATION'] = ActionController::HttpAuthentication::Basic.encode_credentials('user', secret)
       webhook params
     end
-    
+
     before(:each) { StripeEvent.authentication_secret = "secret" }
     after(:each) { StripeEvent.authentication_secret = nil }
-  
+
     it "rejects requests with no secret" do
       stub_event('evt_charge_succeeded')
-    
+
       webhook id: 'evt_charge_succeeded'
       expect(response.code).to eq '401'
     end
-  
+
     it "rejects requests with incorrect secret" do
       stub_event('evt_charge_succeeded')
-    
+
       webhook_with_secret 'incorrect', id: 'evt_charge_succeeded'
       expect(response.code).to eq '401'
     end
-  
+
     it "accepts requests with correct secret" do
       stub_event('evt_charge_succeeded')
-    
+
       webhook_with_secret 'secret', id: 'evt_charge_succeeded'
       expect(response.code).to eq '200'
     end

--- a/spec/dummy/config/application.rb
+++ b/spec/dummy/config/application.rb
@@ -54,11 +54,12 @@ module Dummy
     # parameters by using an attr_accessible or attr_protected declaration.
     # config.active_record.whitelist_attributes = true
 
-    # Enable the asset pipeline
-    config.assets.enabled = true
+    if config.respond_to?(:assets)
+      # Enable the asset pipeline
+      config.assets.enabled = true
 
-    # Version of your assets, change this if you want to expire all your assets
-    config.assets.version = '1.0'
+      # Version of your assets, change this if you want to expire all your assets
+      config.assets.version = '1.0'
+    end
   end
 end
-

--- a/spec/lib/stripe_event_spec.rb
+++ b/spec/lib/stripe_event_spec.rb
@@ -83,6 +83,24 @@ describe StripeEvent do
         expect(events.first[:type]).to  eq 'account.application.deauthorized'
       end
     end
+
+    # Rails 5.1 uses ActionController::Parameters which is not inherited from
+    # ActiveSupport::HashWithIndifferentAccess anymore
+    if Rails::VERSION::MAJOR > 3
+      context "with a subscriber params with indifferent access (controller params)" do
+        it "calls the subscriber with the retrieved event" do
+          StripeEvent.subscribe('account.application.deauthorized', subscriber)
+
+          StripeEvent.instrument(ActionController::Parameters.new(
+            id: 'evt_account_application_deauthorized',
+            type: 'account.application.deauthorized'
+          ))
+
+          expect(events.first.type).to    eq 'account.application.deauthorized'
+          expect(events.first[:type]).to  eq 'account.application.deauthorized'
+        end
+      end
+    end
   end
 
   describe "subscribing to a namespace of event types" do

--- a/stripe_event.gemspec
+++ b/stripe_event.gemspec
@@ -22,7 +22,7 @@ Gem::Specification.new do |s|
 
   s.add_development_dependency "rails", [">= 3.1"]
   s.add_development_dependency "rake", "< 11.0"
-  s.add_development_dependency "rspec-rails", "~> 2.12"
+  s.add_development_dependency "rspec-rails", "~> 3.7"
   s.add_development_dependency "webmock", "~> 1.9"
   s.add_development_dependency "appraisal"
   s.add_development_dependency "coveralls"


### PR DESCRIPTION
- Fixes #85
- Creates appraisals for Rails 5.0 and 5.1
- Adds Ruby 2.4.2 + Rails 5.1 to the matrix
- Upgrades RSpec and fixes deprecation warnings