### PR TITLE
Deprecate StripeEvent.authentication_secret=

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,8 @@ mount StripeEvent::Engine, at: '/my-chosen-path' # provide a custom path
 
 ```ruby
 # config/initializers/stripe.rb
-Stripe.api_key = ENV['STRIPE_SECRET_KEY'] # e.g. sk_live_1234
+Stripe.api_key             = ENV['STRIPE_SECRET_KEY']     # e.g. sk_live_...
+StripeEvent.signing_secret = ENV['STRIPE_SIGNING_SECRET'] # e.g. whsec_...
 
 StripeEvent.configure do |events|
   events.subscribe 'charge.failed' do |event|
@@ -88,7 +89,7 @@ StripeEvent.signing_secret = Rails.application.secrets.stripe_signing_secret
 
 Please refer to Stripe's documentation for more details: https://stripe.com/docs/webhooks#signatures
 
-### Basic authentication (deprecated)
+### Basic authentication (DEPRECATED)
 
 StripeEvent automatically fetches events from Stripe to ensure they haven't been forged. However, that doesn't prevent an attacker who knows your endpoint name and an event's ID from forcing your server to process a legitimate event twice. If that event triggers some useful action, like generating a license key or enabling a delinquent account, you could end up giving something the attacker is supposed to pay for away for free.
 

--- a/app/controllers/stripe_event/webhook_controller.rb
+++ b/app/controllers/stripe_event/webhook_controller.rb
@@ -37,6 +37,13 @@ module StripeEvent
         signature = request.headers['Stripe-Signature']
 
         Stripe::Webhook::Signature.verify_header payload, signature, StripeEvent.signing_secret
+      else
+        ActiveSupport::Deprecation.warn(
+        "[STRIPE_EVENT] Unverified use of stripe webhooks is deprecated and configuration of " +
+        "`StripeEvent.signing_secret=` will be required in 2.x. The value for your specific " +
+        "endpoint's signing secret (starting with `whsec_`) is in your API > Webhooks settings " +
+        "(https://dashboard.stripe.com/account/webhooks). " +
+        "More information can be found here: https://stripe.com/docs/webhooks#signatures")
       end
     rescue Stripe::SignatureVerificationError
       head :bad_request

--- a/lib/stripe_event.rb
+++ b/lib/stripe_event.rb
@@ -46,12 +46,12 @@ module StripeEvent
     end
 
     def authentication_secret=(value)
-      warning = "[STRIPE_EVENT] `StripeEvent.authentication_secret=` is deprecated and will be " +
-                "removed in 2.x. Use `StripeEvent.signing_secret=` instead. The value " +
-                "for your specific endpoint's signing secret (starting with `whsec_`) is in your " +
-                "API > Webhooks settings (https://dashboard.stripe.com/account/webhooks). " +
-                "More information can be found here: https://stripe.com/docs/webhooks#signatures"
-      ActiveSupport::Deprecation.warn warning, caller
+      ActiveSupport::Deprecation.warn(
+        "[STRIPE_EVENT] `StripeEvent.authentication_secret=` is deprecated and will be " +
+        "removed in 2.x. Use `StripeEvent.signing_secret=` instead. The value " +
+        "for your specific endpoint's signing secret (starting with `whsec_`) is in your " +
+        "API > Webhooks settings (https://dashboard.stripe.com/account/webhooks). " +
+        "More information can be found here: https://stripe.com/docs/webhooks#signatures")
       @authentication_secret = value
     end
   end

--- a/lib/stripe_event.rb
+++ b/lib/stripe_event.rb
@@ -44,6 +44,16 @@ module StripeEvent
       namespaced_name = namespace.call(name)
       backend.notifier.listening?(namespaced_name)
     end
+
+    def authentication_secret=(value)
+      warning = "[STRIPE_EVENT] `StripeEvent.authentication_secret=` is deprecated and will be " +
+                "removed in 2.x. Use `StripeEvent.signing_secret=` instead. The value " +
+                "for your specific endpoint's signing secret (starting with `whsec_`) is in your " +
+                "API > Webhooks settings (https://dashboard.stripe.com/account/webhooks). " +
+                "More information can be found here: https://stripe.com/docs/webhooks#signatures"
+      ActiveSupport::Deprecation.warn warning, caller
+      @authentication_secret = value
+    end
   end
 
   class Namespace < Struct.new(:value, :delimiter)


### PR DESCRIPTION
## What does it do?

- Deprecates `StripeEvent.authentication_secret=`. Prefers `StripeEvent.signing_secret=` using [Stripe's improved webhook signature verification](https://stripe.com/docs/webhooks#signatures).

## What else do you need to know?

- The plan is to release this as part of a v1.9.1 release and then later fully remove `authentication_secret` while also simplifying codebase using just `signing_secret` (which would be part of a v2.0.0 release).

## Related Issues

- Initial step for handling #95. 

## Communication

> `StripeEvent.authentication_secret=` is deprecated and will be removed in 2.x. Use `StripeEvent.signing_secret=` instead. The value for your specific endpoint's signing secret (starting with `whsec_`) is in your API > Webhooks settings (https://dashboard.stripe.com/account/webhooks). More information can be found here: https://stripe.com/docs/webhooks#signatures
 