### PR TITLE
Only support signed webhooks (require signing_secret configuration)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,12 @@
-### 1.9.1 (November 30, 2017)
+### PENDING 2.0.0 (TBD)
+
+**Backwards incompatible release. [Only signed webhooks are supported](https://stripe.com/docs/webhooks#signatures).**
+
+- **Requires `StripeEvent.signing_secret` configuration** (#95, #97)
+- Removes `StripeEvent.authentication_secret` and associated basic auth support (#97)
+- Adds `StripeEvent.event_filter` (replaces use-cases for the now removed `event_retriever` config) (#97)
+
+### 1.9.1 (December 5, 2017)
 
 This release is in preparation for some backward incompatible changes due to
 arrive in v2.0.0.  It is highly recommended that everyone secure their webhook

--- a/README.md
+++ b/README.md
@@ -89,29 +89,6 @@ StripeEvent.signing_secret = Rails.application.secrets.stripe_signing_secret
 
 Please refer to Stripe's documentation for more details: https://stripe.com/docs/webhooks#signatures
 
-### Basic authentication (DEPRECATED)
-
-StripeEvent automatically fetches events from Stripe to ensure they haven't been forged. However, that doesn't prevent an attacker who knows your endpoint name and an event's ID from forcing your server to process a legitimate event twice. If that event triggers some useful action, like generating a license key or enabling a delinquent account, you could end up giving something the attacker is supposed to pay for away for free.
-
-To prevent this, StripeEvent supports using HTTP Basic authentication on your webhook endpoint. If only Stripe knows the basic authentication password, this ensures that the request really comes from Stripe. Here's what you do:
-
-1. Arrange for a secret key to be available in your application's environment variables or `secrets.yml` file. You can generate a suitable secret with the `rake secret` command. (Remember, the `secrets.yml` file shouldn't contain production secrets directly; it should use ERB to include them.)
-
-2. Configure StripeEvent to require that secret be used as a basic authentication password, using code along the lines of these examples:
-
-    ```ruby
-    # STRIPE_WEBHOOK_SECRET environment variable
-    StripeEvent.authentication_secret = ENV['STRIPE_WEBHOOK_SECRET']
-    # stripe_webhook_secret key in secrets.yml file
-    StripeEvent.authentication_secret = Rails.application.secrets.stripe_webhook_secret
-    ```
-
-3. When you specify your webhook's URL in Stripe's settings, include the secret as a password in the URL, along with any username:
-
-        https://stripe:my-secret-key@myapplication.com/my-webhook-path
-
-This is only truly secure if your webhook endpoint is accessed over SSL, which Stripe strongly recommends anyway.
-
 ## Configuration
 
 If you have built an application that has multiple Stripe accounts--say, each of your customers has their own--you may want to define your own way of retrieving events from Stripe (e.g. perhaps you want to use the [account parameter](https://stripe.com/docs/connect/webhooks) from the top level to detect the customer for the event, then grab their specific API key). You can do this:

--- a/app/controllers/stripe_event/webhook_controller.rb
+++ b/app/controllers/stripe_event/webhook_controller.rb
@@ -1,42 +1,24 @@
 module StripeEvent
   class WebhookController < ActionController::Base
-    if respond_to?(:before_action)
-      before_action :verify_signature
-    else
-      before_filter :verify_signature
-    end
-
     def event
-      StripeEvent.instrument(params)
+      StripeEvent.instrument(verified_event)
       head :ok
-    rescue StripeEvent::UnauthorizedError => e
+    rescue Stripe::SignatureVerificationError => e
       log_error(e)
-      head :unauthorized
+      head :bad_request
     end
 
     private
 
+    def verified_event
+      payload   = request.body.read
+      signature = request.headers['Stripe-Signature']
+      Stripe::Webhook.construct_event(payload, signature, StripeEvent.signing_secret.to_s)
+    end
+
     def log_error(e)
       logger.error e.message
       e.backtrace.each { |line| logger.error "  #{line}" }
-    end
-
-    def verify_signature
-      if StripeEvent.signing_secret
-        payload   = request.body.read
-        signature = request.headers['Stripe-Signature']
-
-        Stripe::Webhook::Signature.verify_header payload, signature, StripeEvent.signing_secret
-      else
-        ActiveSupport::Deprecation.warn(
-        "[STRIPE_EVENT] Unverified use of stripe webhooks is deprecated and configuration of " +
-        "`StripeEvent.signing_secret=` will be required in 2.x. The value for your specific " +
-        "endpoint's signing secret (starting with `whsec_`) is in your API > Webhooks settings " +
-        "(https://dashboard.stripe.com/account/webhooks). " +
-        "More information can be found here: https://stripe.com/docs/webhooks#signatures")
-      end
-    rescue Stripe::SignatureVerificationError
-      head :bad_request
     end
   end
 end

--- a/app/controllers/stripe_event/webhook_controller.rb
+++ b/app/controllers/stripe_event/webhook_controller.rb
@@ -1,10 +1,8 @@
 module StripeEvent
   class WebhookController < ActionController::Base
     if respond_to?(:before_action)
-      before_action :request_authentication
       before_action :verify_signature
     else
-      before_filter :request_authentication
       before_filter :verify_signature
     end
 
@@ -21,14 +19,6 @@ module StripeEvent
     def log_error(e)
       logger.error e.message
       e.backtrace.each { |line| logger.error "  #{line}" }
-    end
-
-    def request_authentication
-      if StripeEvent.authentication_secret
-        authenticate_or_request_with_http_basic do |username, password|
-          ActiveSupport::SecurityUtils.variable_size_secure_compare password, StripeEvent.authentication_secret
-        end
-      end
     end
 
     def verify_signature

--- a/lib/stripe_event.rb
+++ b/lib/stripe_event.rb
@@ -4,7 +4,7 @@ require "stripe_event/engine" if defined?(Rails)
 
 module StripeEvent
   class << self
-    attr_accessor :adapter, :backend, :event_retriever, :namespace, :authentication_secret, :signing_secret
+    attr_accessor :adapter, :backend, :event_retriever, :namespace, :signing_secret
 
     def configure(&block)
       raise ArgumentError, "must provide a block" unless block_given?
@@ -43,16 +43,6 @@ module StripeEvent
     def listening?(name)
       namespaced_name = namespace.call(name)
       backend.notifier.listening?(namespaced_name)
-    end
-
-    def authentication_secret=(value)
-      ActiveSupport::Deprecation.warn(
-        "[STRIPE_EVENT] `StripeEvent.authentication_secret=` is deprecated and will be " +
-        "removed in 2.x. Use `StripeEvent.signing_secret=` instead. The value " +
-        "for your specific endpoint's signing secret (starting with `whsec_`) is in your " +
-        "API > Webhooks settings (https://dashboard.stripe.com/account/webhooks). " +
-        "More information can be found here: https://stripe.com/docs/webhooks#signatures")
-      @authentication_secret = value
     end
   end
 

--- a/spec/controllers/webhook_controller_spec.rb
+++ b/spec/controllers/webhook_controller_spec.rb
@@ -60,37 +60,6 @@ describe StripeEvent::WebhookController, type: :controller do
     expect { webhook id: 'evt_charge_succeeded' }.to raise_error(Stripe::StripeError, /testing/)
   end
 
-  context "with an authentication secret" do
-    def webhook_with_secret(secret, params)
-      request.env['HTTP_AUTHORIZATION'] = ActionController::HttpAuthentication::Basic.encode_credentials('user', secret)
-      webhook params
-    end
-
-    before(:each) { StripeEvent.authentication_secret = "secret" }
-    after(:each) { StripeEvent.authentication_secret = nil }
-
-    it "rejects requests with no secret" do
-      stub_event('evt_charge_succeeded')
-
-      webhook id: 'evt_charge_succeeded'
-      expect(response.code).to eq '401'
-    end
-
-    it "rejects requests with incorrect secret" do
-      stub_event('evt_charge_succeeded')
-
-      webhook_with_secret 'incorrect', id: 'evt_charge_succeeded'
-      expect(response.code).to eq '401'
-    end
-
-    it "accepts requests with correct secret" do
-      stub_event('evt_charge_succeeded')
-
-      webhook_with_secret 'secret', id: 'evt_charge_succeeded'
-      expect(response.code).to eq '200'
-    end
-  end
-
   context "with a signing secret" do
     def webhook_with_signature(signature, params)
       request.env['HTTP_STRIPE_SIGNATURE'] = signature

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -13,13 +13,15 @@ RSpec.configure do |config|
   end
 
   config.before do
-    @event_retriever = StripeEvent.event_retriever
+    @signing_secret = StripeEvent.signing_secret
+    @event_filter = StripeEvent.event_filter
     @notifier = StripeEvent.backend.notifier
     StripeEvent.backend.notifier = @notifier.class.new
   end
 
   config.after do
-    StripeEvent.event_retriever = @event_retriever
+    StripeEvent.signing_secret = @signing_secret
+    StripeEvent.event_filter = @event_filter
     StripeEvent.backend.notifier = @notifier
   end
 end

--- a/spec/support/fixtures/evt_invalid_id.json
+++ b/spec/support/fixtures/evt_invalid_id.json
@@ -1,7 +1,0 @@
-{
-  "error": {
-    "message": "No such notification: invalid-id",
-    "param": "id",
-    "type": "invalid_request_error"
-  }
-}


### PR DESCRIPTION
## What does it do?

- Removes `authentication_secret` and associated basic auth support
- Requires `signing_secret` usage
- Adds `event_filter` (replaces use-cases for `event_retriever`)
- Updates README with `signing_secret` and `event_filter` example usage

## What else do you need to know?

This is a backwards incompatible set of changes, but it simplifies the overall codebase while also employing Stripe's best practices. The plan is to make this part of a v2.0.0 release.

## Related Issues

- Closes #95


 