### PR TITLE
Support multiple signing secrets

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,9 @@
 ### PENDING 2.0.0 (TBD)
 
-**Backwards incompatible release. [Only signed webhooks are supported](https://stripe.com/docs/webhooks#signatures).**
+**Backwards incompatible release. [Signed webhooks are now required.](https://stripe.com/docs/webhooks#signatures).**
 
 - **Requires `StripeEvent.signing_secret` configuration** (#95, #97)
+- Adds support for multiple signing secrets using `StripeEvent.signing_secrets` (#98, #99)
 - Removes `StripeEvent.authentication_secret` and associated basic auth support (#97)
 - Adds `StripeEvent.event_filter` (replaces use-cases for the now removed `event_retriever` config) (#97)
 

--- a/README.md
+++ b/README.md
@@ -79,15 +79,28 @@ end
 
 ## Securing your webhook endpoint
 
-### Authenticating webhooks with signatures (recommended)
+### Authenticating webhooks with signatures
 
 Stripe will cryptographically sign webhook payloads with a signature that is included in a special header sent with the request. Verifying this signature lets your application properly authenticate the request originated from Stripe. To leverage this feature, please set the `signing_secret` configuration value:
 
-```
+```ruby
 StripeEvent.signing_secret = Rails.application.secrets.stripe_signing_secret
 ```
 
 Please refer to Stripe's documentation for more details: https://stripe.com/docs/webhooks#signatures
+
+### Support for multiple signing secrets
+
+Sometimes, you'll have multiple Stripe webhook subscriptions pointing at your application each with a different signing secret. For example, you might have both a main Account webhook and a webhook for a Connect application point at the same endpoint. It's possible to configure an array of signing secrets using the `signing_secrets` configuration option. The first one that successfully matches for each incoming webhook will be used to verify your incoming events.
+
+```ruby
+StripeEvent.signing_secrets = [
+  Rails.application.secrets.stripe_account_signing_secret,
+  Rails.application.secrets.stripe_connect_signing_secret,
+]
+```
+
+(NOTE: `signing_secret=` and `signing_secrets=` are just aliases for one another)
 
 ## Configuration
 

--- a/lib/stripe_event.rb
+++ b/lib/stripe_event.rb
@@ -4,7 +4,8 @@ require "stripe_event/engine" if defined?(Rails)
 
 module StripeEvent
   class << self
-    attr_accessor :adapter, :backend, :namespace, :event_filter, :signing_secret
+    attr_accessor :adapter, :backend, :namespace, :event_filter
+    attr_reader :signing_secrets
 
     def configure(&block)
       raise ArgumentError, "must provide a block" unless block_given?
@@ -28,6 +29,15 @@ module StripeEvent
     def listening?(name)
       namespaced_name = namespace.call(name)
       backend.notifier.listening?(namespaced_name)
+    end
+
+    def signing_secret=(value)
+      @signing_secrets = Array(value)
+    end
+    alias signing_secrets= signing_secret=
+
+    def signing_secret
+      self.signing_secrets && self.signing_secrets.first
     end
   end
 

--- a/spec/controllers/webhook_controller_spec.rb
+++ b/spec/controllers/webhook_controller_spec.rb
@@ -2,14 +2,15 @@ require 'rails_helper'
 require 'spec_helper'
 
 describe StripeEvent::WebhookController, type: :controller do
-  let(:secret) { 'secret' }
+  let(:secret1) { 'secret1`' }
+  let(:secret2) { 'secret2' }
   let(:charge_succeeded) { stub_event('evt_charge_succeeded') }
 
   def stub_event(identifier)
     JSON.parse(File.read("spec/support/fixtures/#{identifier}.json"))
   end
 
-  def generate_signature(params)
+  def generate_signature(params, secret)
     payload   = params.to_json
     timestamp = Time.now.to_i
     signature = Stripe::Webhook::Signature.send(:compute_signature, "#{timestamp}.#{payload}", secret)
@@ -23,8 +24,8 @@ describe StripeEvent::WebhookController, type: :controller do
     post :event
   end
 
-  def webhook_with_signature(params)
-    webhook generate_signature(params), params
+  def webhook_with_signature(params, secret = secret1)
+    webhook generate_signature(params, secret), params
   end
 
   routes { StripeEvent::Engine.routes }
@@ -44,7 +45,7 @@ describe StripeEvent::WebhookController, type: :controller do
   end
 
   context "with a signing secret" do
-    before(:each) { StripeEvent.signing_secret = secret }
+    before(:each) { StripeEvent.signing_secret = secret1 }
 
     it "denies missing signature" do
       webhook nil, charge_succeeded
@@ -56,8 +57,13 @@ describe StripeEvent::WebhookController, type: :controller do
       expect(response.code).to eq '400'
     end
 
-    it "succeeds with valid signature" do
-      webhook_with_signature charge_succeeded
+    it "denies signature from wrong secret" do
+      webhook_with_signature charge_succeeded, 'bogus'
+      expect(response.code).to eq '400'
+    end
+
+    it "succeeds with valid signature from correct secret" do
+      webhook_with_signature charge_succeeded, secret1
       expect(response.code).to eq '200'
     end
 
@@ -86,6 +92,35 @@ describe StripeEvent::WebhookController, type: :controller do
       StripeEvent.subscribe('charge.succeeded') { |evt| raise Stripe::StripeError, "testing" }
 
       expect { webhook_with_signature(charge_succeeded) }.to raise_error(Stripe::StripeError, /testing/)
+    end
+  end
+
+  context "with multiple signing secrets" do
+    before(:each) { StripeEvent.signing_secrets = [secret1, secret2] }
+
+    it "denies missing signature" do
+      webhook nil, charge_succeeded
+      expect(response.code).to eq '400'
+    end
+
+    it "denies invalid signature" do
+      webhook "invalid signature", charge_succeeded
+      expect(response.code).to eq '400'
+    end
+
+    it "denies signature from wrong secret" do
+      webhook_with_signature charge_succeeded, 'bogus'
+      expect(response.code).to eq '400'
+    end
+
+    it "succeeds with valid signature from first secret" do
+      webhook_with_signature charge_succeeded, secret1
+      expect(response.code).to eq '200'
+    end
+
+    it "succeeds with valid signature from second secret" do
+      webhook_with_signature charge_succeeded, secret2
+      expect(response.code).to eq '200'
     end
   end
 end

--- a/spec/controllers/webhook_controller_spec.rb
+++ b/spec/controllers/webhook_controller_spec.rb
@@ -2,7 +2,7 @@ require 'rails_helper'
 require 'spec_helper'
 
 describe StripeEvent::WebhookController, type: :controller do
-  let(:secret1) { 'secret1`' }
+  let(:secret1) { 'secret1' }
   let(:secret2) { 'secret2' }
   let(:charge_succeeded) { stub_event('evt_charge_succeeded') }
 

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -13,14 +13,14 @@ RSpec.configure do |config|
   end
 
   config.before do
-    @signing_secret = StripeEvent.signing_secret
+    @signing_secrets = StripeEvent.signing_secrets
     @event_filter = StripeEvent.event_filter
     @notifier = StripeEvent.backend.notifier
     StripeEvent.backend.notifier = @notifier.class.new
   end
 
   config.after do
-    StripeEvent.signing_secret = @signing_secret
+    StripeEvent.signing_secrets = @signing_secrets
     StripeEvent.event_filter = @event_filter
     StripeEvent.backend.notifier = @notifier
   end


### PR DESCRIPTION
## What does it do?

- Adds `StripeEvent.signing_secrets` as a config option
- Adds support for multiple signing secrets
- Adds docs to README for multiple signing secret support (including possible use-case)

## What else do you need to know?

- When multiple signing secrets are enabled, the webhook iterates over each of them looking for one that yields a matching signature for the body payload. Once a match is found, that secret is used for the subsequent verification check while constructing the new event object. 
- When only one signing secret is enabled, the header verification is short-circuited (skipped) and the secret is passed directly to verification check that's done automatically when constructing a new event object.

## Related Issues

- Closes #98

 