### PR TITLE
Skip verify_authenticity_token if default_protect_from_forgery enabled

### DIFF
--- a/app/controllers/stripe_event/webhook_controller.rb
+++ b/app/controllers/stripe_event/webhook_controller.rb
@@ -1,5 +1,9 @@
 module StripeEvent
   class WebhookController < ActionController::Base
+    if Rails.application.config.action_controller.default_protect_from_forgery
+      skip_before_action :verify_authenticity_token
+    end
+
     def event
       StripeEvent.instrument(verified_event)
       head :ok

--- a/spec/dummy/config/initializers/new_framework_defaults_5_2.rb
+++ b/spec/dummy/config/initializers/new_framework_defaults_5_2.rb
@@ -1,0 +1,4 @@
+if Gem::Version.new(Rails::VERSION::STRING) > Gem::Version.new("5.1.999")
+  # New default in Rails 5.2
+  Rails.application.config.action_controller.default_protect_from_forgery = true
+end


### PR DESCRIPTION
This is a new default in Rails 5.2.  See https://github.com/integrallis/stripe_event/issues/105#issuecomment-361138469

```ruby
# config/initializers/new_framework_defaults_5_2.rb
Rails.application.config.action_controller.default_protect_from_forgery = true
```

Fixes #105 