### PR TITLE
Add support for Stripe v4.x

### DIFF
--- a/spec/controllers/webhook_controller_spec.rb
+++ b/spec/controllers/webhook_controller_spec.rb
@@ -21,7 +21,7 @@ describe StripeEvent::WebhookController, type: :controller do
   def webhook(signature, params)
     request.env['HTTP_STRIPE_SIGNATURE'] = signature
     request.env['RAW_POST_DATA'] = params.to_json # works with Rails 3, 4, or 5
-    post :event
+    post :event, body: params.to_json
   end
 
   def webhook_with_signature(params, secret = secret1)

--- a/stripe_event.gemspec
+++ b/stripe_event.gemspec
@@ -18,7 +18,7 @@ Gem::Specification.new do |s|
   s.test_files  = `git ls-files -- Appraisals {spec,gemfiles}/*`.split("\n")
 
   s.add_dependency "activesupport", ">= 3.1"
-  s.add_dependency "stripe", [">= 2.8", "< 4.0"]
+  s.add_dependency "stripe", [">= 2.8", "< 5.0"]
 
   s.add_development_dependency "rails", [">= 3.1"]
   s.add_development_dependency "rake", "< 11.0"


### PR DESCRIPTION
Fixes #118.

Stripe gem is up to 4.2.x already, so this commit will allow anything below stripe v5.x.