### PR TITLE
Fix deprecation warning on Ruby 2.7 and test against on Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,15 +2,13 @@ language: ruby
 cache: bundler
 
 rvm:
-  - 2.3
-  - 2.4
   - 2.5
   - 2.6
 
 gemfile:
-  - gemfiles/rails4.2.gemfile
   - gemfiles/rails5.1.gemfile
   - gemfiles/rails5.2.gemfile
+  - gemfiles/rails6.0.gemfile
   - gemfiles/stripe3.gemfile
   - gemfiles/stripe4.gemfile
   - gemfiles/stripe5.gemfile
@@ -19,17 +17,12 @@ matrix:
   include:
     - rvm: 2.3
       gemfile: gemfiles/rails3.2.gemfile
-    - rvm: 2.5
-      gemfile: gemfiles/rails6.0.gemfile
-    - rvm: 2.6
-      gemfile: gemfiles/rails6.0.gemfile
+    - rvm: 2.3
+      gemfile: gemfiles/rails4.2.gemfile
+    - rvm: 2.4
+      gemfile: gemfiles/rails4.2.gemfile
     - rvm: 2.6
       gemfile: gemfiles/rails_master.gemfile
-  exclude:
-    - rvm: 2.5
-      gemfile: gemfiles/rails4.2.gemfile
-    - rvm: 2.6
-      gemfile: gemfiles/rails4.2.gemfile
   allow_failures:
     - gemfile: gemfiles/rails_master.gemfile
   fast_finish: true

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,6 +4,7 @@ cache: bundler
 rvm:
   - 2.5
   - 2.6
+  - 2.7
 
 gemfile:
   - gemfiles/rails5.1.gemfile
@@ -21,7 +22,7 @@ matrix:
       gemfile: gemfiles/rails4.2.gemfile
     - rvm: 2.4
       gemfile: gemfiles/rails4.2.gemfile
-    - rvm: 2.6
+    - rvm: ruby
       gemfile: gemfiles/rails_master.gemfile
   allow_failures:
     - gemfile: gemfiles/rails_master.gemfile

--- a/lib/stripe_event.rb
+++ b/lib/stripe_event.rb
@@ -18,11 +18,13 @@ module StripeEvent
       backend.instrument namespace.call(event.type), event if event
     end
 
-    def subscribe(name, callable = Proc.new)
+    def subscribe(name, callable = nil, &block)
+      callable ||= block
       backend.subscribe namespace.to_regexp(name), adapter.call(callable)
     end
 
-    def all(callable = Proc.new)
+    def all(callable = nil, &block)
+      callable ||= block
       subscribe nil, callable
     end
 

--- a/stripe_event.gemspec
+++ b/stripe_event.gemspec
@@ -23,7 +23,7 @@ Gem::Specification.new do |s|
   s.add_development_dependency "appraisal"
   s.add_development_dependency "coveralls"
   s.add_development_dependency "rails", [">= 3.1"]
-  s.add_development_dependency "rake", "< 11.0"
+  s.add_development_dependency "rake"
   s.add_development_dependency "rspec-rails", "~> 3.7"
   s.add_development_dependency "webmock", "~> 1.9"
 end


### PR DESCRIPTION
This adds Ruby 2.7 to the test matrix, reorganizes it to make 2.3 and 2.4 (both end-of-life) to be included exceptions, and fixes a deprecation warning on Ruby 2.7. I also ran into a different deprecation warning running under and old version of Rake so I've tried to relax the constraint.

Closes #129 