### PR TITLE
Return 422 if event processing failes

### DIFF
--- a/app/controllers/stripe_event/webhook_controller.rb
+++ b/app/controllers/stripe_event/webhook_controller.rb
@@ -10,6 +10,8 @@ module StripeEvent
     rescue Stripe::SignatureVerificationError => e
       log_error(e)
       head :bad_request
+    rescue StripeEvent::ProcessError
+      head :unprocessable_entity
     end
 
     private

--- a/lib/stripe_event.rb
+++ b/lib/stripe_event.rb
@@ -64,6 +64,7 @@ module StripeEvent
 
   class Error < StandardError; end
   class UnauthorizedError < Error; end
+  class ProcessError < Error; end
 
   self.adapter = NotificationAdapter
   self.backend = ActiveSupport::Notifications


### PR DESCRIPTION
I introduced a `StripeEvent::ProcessError`. If catched in the `WebhookController` a 422 StatusCode is returned. I think it breaks the processing of the event by other subscribers, so it is not a good solution to the issue it tries to solve: https://github.com/integrallis/stripe_event/issues/131