### PR TITLE
Ability to bypass signature verification

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,4 @@ gemfiles/*.lock
 coverage/*
 .ruby-version
 .ruby-gemset
+vendor/bundle

--- a/lib/stripe_event.rb
+++ b/lib/stripe_event.rb
@@ -4,7 +4,7 @@ require "stripe_event/engine" if defined?(Rails)
 
 module StripeEvent
   class << self
-    attr_accessor :adapter, :backend, :namespace, :event_filter
+    attr_accessor :adapter, :backend, :namespace, :event_filter, :skip_signature_verification
     attr_reader :signing_secrets
 
     def configure(&block)

--- a/lib/stripe_event/version.rb
+++ b/lib/stripe_event/version.rb
@@ -1,3 +1,3 @@
 module StripeEvent
-  VERSION = "2.3.1"
+  VERSION = "2.4.0"
 end

--- a/spec/controllers/webhook_controller_spec.rb
+++ b/spec/controllers/webhook_controller_spec.rb
@@ -39,6 +39,18 @@ describe StripeEvent::WebhookController, type: :controller do
 
   routes { StripeEvent::Engine.routes }
 
+  context "bypass signature verification" do
+
+    before { StripeEvent.skip_signature_verification = true }
+    after  { StripeEvent.skip_signature_verification = false }
+
+    it "succeeds" do
+      webhook "invalid signature", charge_succeeded
+      expect(response.code).to eq '200'
+    end
+
+  end
+
   context "without a signing secret" do
     before(:each) { StripeEvent.signing_secret = nil }
 

--- a/spec/lib/stripe_event_spec.rb
+++ b/spec/lib/stripe_event_spec.rb
@@ -28,6 +28,15 @@ describe StripeEvent do
     end
   end
 
+  describe "bypass signature verification" do
+
+    it "sets and gets skip_signature_verification" do
+      StripeEvent.skip_signature_verification = true
+      expect(StripeEvent.skip_signature_verification).to be true
+    end
+
+  end
+
   describe "subscribing to a specific event type" do
     context "with a block subscriber" do
       it "calls the subscriber with the retrieved event" do


### PR DESCRIPTION
Implemented the ability to bypass signature verification as a way to help with upgrading to 2.x. I would suggest this be removed once we get to 3.x.

In our particular case, we do not control the configuration - our users can set up an integration with stripe by providing credentials. It so happens that users on older versions of the API were not required to provide a signing secret. Upgrading to 2.x therefore breaks these implementations.

By default, signature verification is enforced. Set the skip_signature_verification attribute to true to bypass verification.

```
StripeEvent.skip_signature_verification = true
```

The implementation relies on using ```Stripe::Event.construct_from``` directly.