### PR TITLE
Fix signature validation error if the first signing secret is nil

### DIFF
--- a/lib/stripe_event.rb
+++ b/lib/stripe_event.rb
@@ -34,7 +34,7 @@ module StripeEvent
     end
 
     def signing_secret=(value)
-      @signing_secrets = Array(value)
+      @signing_secrets = Array(value).compact
     end
     alias signing_secrets= signing_secret=
 

--- a/spec/controllers/webhook_controller_spec.rb
+++ b/spec/controllers/webhook_controller_spec.rb
@@ -132,4 +132,18 @@ describe StripeEvent::WebhookController, type: :controller do
       expect(response.code).to eq '200'
     end
   end
+
+  context "with multiple signing secrets first of which is nil" do
+    before(:each) { StripeEvent.signing_secrets = [nil, secret1, secret2] }
+
+    it "succeeds with valid signature from first secret" do
+      webhook_with_signature charge_succeeded, secret1
+      expect(response.code).to eq '200'
+    end
+
+    it "succeeds with valid signature from second secret" do
+      webhook_with_signature charge_succeeded, secret2
+      expect(response.code).to eq '200'
+    end
+  end
 end


### PR DESCRIPTION
This pull requests fixes the bug described in this [issue](https://github.com/integrallis/stripe_event/issues/145).

Motivation:
`signing_secret` [method](https://github.com/integrallis/stripe_event/blob/master/lib/stripe_event.rb#L41) returns `false` if the first secret in the array is `nil` which is actually a valid state (a variable might be set to nil in one environment and not nil in another environment):

```
StripeEvent.signing_secrets = [
  ENV['STRIPE_SIGNING_SECRET_DEV_GB'], # nil
  ENV['STRIPE_SIGNING_SECRET_PROD_GB'], # not nil
  ...
]
```

Using `compact` fixes this issue.

Fixes #145