### PR TITLE
Re-introduce StripeEvent::ProcessError

### DIFF
--- a/app/controllers/stripe_event/webhook_controller.rb
+++ b/app/controllers/stripe_event/webhook_controller.rb
@@ -10,6 +10,8 @@ module StripeEvent
     rescue Stripe::SignatureVerificationError => e
       log_error(e)
       head :bad_request
+    rescue StripeEvent::ProcessError
+      head :unprocessable_entity
     end
 
     private

--- a/lib/stripe_event.rb
+++ b/lib/stripe_event.rb
@@ -66,6 +66,7 @@ module StripeEvent
 
   class Error < StandardError; end
   class UnauthorizedError < Error; end
+  class ProcessError < Error; end
 
   self.adapter = NotificationAdapter
   self.backend = ActiveSupport::Notifications

--- a/spec/controllers/webhook_controller_spec.rb
+++ b/spec/controllers/webhook_controller_spec.rb
@@ -146,4 +146,14 @@ describe StripeEvent::WebhookController, type: :controller do
       expect(response.code).to eq '200'
     end
   end
+
+  context "raising an error when things go bad and stripe should retry" do
+    before(:each) { StripeEvent.signing_secrets = [secret1] }
+
+    it "responds with 4xx" do
+      allow(StripeEvent).to receive(:instrument) { raise StripeEvent::ProcessError, "retry please" }
+      webhook_with_signature charge_succeeded, secret1
+      expect(response.code).to eq '422'
+    end
+  end
 end


### PR DESCRIPTION
We've got a use case for this error @wistia and we'd love to use this error class instead of monkey-patching this gem. @rmm5t any chance you'd up for a 2.5.1 or 2.6.0 release for this?

Based on and closes #132.