### PR TITLE
docs: Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,8 +63,8 @@ end
 
 ```ruby
 StripeEvent.configure do |events|
-  events.all BillingEventLogger.new(Rails.logger)
-  events.subscribe 'customer.created', CustomerCreated.new
+  events.all ->(event) { BillingEventLogger.new(Rails.logger).call(event) }
+  events.subscribe 'customer.created', ->(event) { CustomerCreated.new.call(event) }
 end
 ```
 


### PR DESCRIPTION
Setting up according to the README will cause problems because the same instance will continue to be used.
To solve this problem, the README must be changed and the configuration must be changed as follows.

```ruby
# Before
StripeEvent.configure do |events|
  events.all BillingEventLogger.new(Rails.logger)
  events.subscribe 'customer.created', CustomerCreated.new
end

# After
StripeEvent.configure do |events|
  events.all ->(event) { BillingEventLogger.new(Rails.logger).call(event) }
  events.subscribe 'customer.created', ->(event) { CustomerCreated.new.call(event) }
end
```

It should pass the procedures including initialization wrapped by Lambda instead of instances which already initialized in the configuration.