### PR TITLE
Fix build matrix for older rails versions

### DIFF
--- a/gemfiles/rails6.0.gemfile
+++ b/gemfiles/rails6.0.gemfile
@@ -3,5 +3,6 @@
 source "https://rubygems.org"
 
 gem "rails", "~> 6.0.0"
+gem "concurrent-ruby", "<= 1.3.4"
 
 gemspec path: "../"

--- a/gemfiles/rails6.1.gemfile
+++ b/gemfiles/rails6.1.gemfile
@@ -3,5 +3,6 @@
 source "https://rubygems.org"
 
 gem "rails", "~> 6.1.0"
+gem "concurrent-ruby", "<= 1.3.4"
 
 gemspec path: "../"

--- a/gemfiles/rails7.0.gemfile
+++ b/gemfiles/rails7.0.gemfile
@@ -3,5 +3,6 @@
 source "https://rubygems.org"
 
 gem "rails", "~> 7.0.0"
+gem "concurrent-ruby", "<= 1.3.4"
 
 gemspec path: "../"

--- a/gemfiles/stripe3.gemfile
+++ b/gemfiles/stripe3.gemfile
@@ -3,5 +3,7 @@
 source "https://rubygems.org"
 
 gem "stripe", "~> 3.0"
+gem "rails", "~> 6.0"
+gem "concurrent-ruby", "<= 1.3.4"
 
 gemspec path: "../"

--- a/gemfiles/stripe4.gemfile
+++ b/gemfiles/stripe4.gemfile
@@ -3,5 +3,7 @@
 source "https://rubygems.org"
 
 gem "stripe", "~> 4.0"
+gem "rails", "~> 6.0"
+gem "concurrent-ruby", "<= 1.3.4"
 
 gemspec path: "../"


### PR DESCRIPTION
concurrent-ruby 1.3.5 is no longer compatible with Rails <=7.0