### PR TITLE
Support callable signing_secrets for dynamic configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -99,6 +99,19 @@ StripeEvent.signing_secrets = [
 
 (NOTE: `signing_secret=` and `signing_secrets=` are just aliases for one another)
 
+### Dynamic signing secrets with callables
+
+For multi-region deployments or dynamic configuration scenarios where signing secrets may vary per request, you can use a callable (lambda/proc) that will be resolved at request time:
+
+```ruby
+StripeEvent.signing_secrets = -> {
+  [
+    Rails.application.secrets.stripe_account_signing_secret,
+    Rails.application.secrets.stripe_connect_signing_secret,
+  ]
+}
+```
+
 ## Configuration
 
 If you have built an application that has multiple Stripe accounts--say, each of your customers has their own--you may want to define your own way of retrieving events from Stripe (e.g. perhaps you want to use the [account parameter](https://stripe.com/docs/connect/webhooks) from the top level to detect the customer for the event, then grab their specific API key). You can do this:

--- a/lib/stripe_event.rb
+++ b/lib/stripe_event.rb
@@ -5,7 +5,6 @@ require "stripe_event/engine" if defined?(Rails)
 module StripeEvent
   class << self
     attr_accessor :adapter, :backend, :namespace, :event_filter
-    attr_reader :signing_secrets
 
     def configure(&block)
       raise ArgumentError, "must provide a block" unless block_given?
@@ -37,6 +36,10 @@ module StripeEvent
       @signing_secrets = Array(value).compact
     end
     alias signing_secrets= signing_secret=
+
+    def signing_secrets
+      @signing_secrets&.flat_map { |s| s.respond_to?(:call) ? s.call : s }&.compact
+    end
 
     def signing_secret
       self.signing_secrets && self.signing_secrets.first

--- a/spec/lib/stripe_event_spec.rb
+++ b/spec/lib/stripe_event_spec.rb
@@ -130,6 +130,38 @@ describe StripeEvent do
     end
   end
 
+  describe ".signing_secrets" do
+    it "returns static secrets as-is" do
+      StripeEvent.signing_secrets = ["secret1", "secret2"]
+
+      expect(StripeEvent.signing_secrets).to eq ["secret1", "secret2"]
+    end
+
+    it "resolves callable secrets" do
+      StripeEvent.signing_secrets = [-> { "secret1" }]
+
+      expect(StripeEvent.signing_secrets).to eq ["secret1"]
+    end
+
+    it "flattens callable secrets that return arrays" do
+      StripeEvent.signing_secrets = [-> { ["secret1", "secret2"] }]
+
+      expect(StripeEvent.signing_secrets).to eq ["secret1", "secret2"]
+    end
+
+    it "handles mixed static and callable secrets" do
+      StripeEvent.signing_secrets = ["secret1", -> { "secret2" }]
+
+      expect(StripeEvent.signing_secrets).to eq ["secret1", "secret2"]
+    end
+
+    it "compacts nil values from resolved callables" do
+      StripeEvent.signing_secrets = [-> { nil }, "secret1"]
+
+      expect(StripeEvent.signing_secrets).to eq ["secret1"]
+    end
+  end
+
   describe StripeEvent::Namespace do
     let(:namespace) { StripeEvent.namespace }
 


### PR DESCRIPTION
**Why?**
Multi-tenant Rails applications often need to use different Stripe webhook signing secrets for different tenants/regions. Currently, signing_secrets must be set to a static array at boot time, which doesn't work well for applications where the correct signing secrets are only known at request time.
This change allows signing_secrets to accept a callable (lambda/proc) that is evaluated on each webhook request, enabling dynamic resolution of signing secrets based on the current request context.

**What?**
-  Added a custom getter for signing_secrets that resolves callable values (lambdas/procs) before returning
-  Added documentation explaining the callable support
-  Added tests for callable signing_secrets configuration
After this change, applications can configure StripeEvent like this:
```
StripeEvent.signing_secrets = -> { CurrentTenant.stripe_signing_secrets }
```

**See Also**

[activerecord-tenanted ](https://github.com/basecamp/activerecord-tenanted)- This is the gem I am using that enables multi-tenant Rails applications, which is an example use case for this feature.